### PR TITLE
修复记忆上传失效问题，新增跨会话记忆互通支持并优化 Token 输入

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -38,10 +38,17 @@
     "default": "system"
   },
   "private_injection_type": {
-    "type": "string",
-    "description": "私聊记忆注入类型",
-    "options": ["user", "system"],
-    "hint": "user: 将记忆临时注入到用户prompt中; system: 将记忆作为system消息添加到上下文中",
-    "default": "user"
-  }
+  "type": "string",
+  "description": "私聊记忆注入类型",
+  "options": ["user", "system"],
+  "hint": "user: 将记忆临时注入到用户prompt中; system: 将记忆作为system消息添加到上下文中",
+  "default": "user"
+},
+"memory_scope": {
+  "type": "string",
+  "description": "记忆作用域",
+  "options": ["isolated", "global"],
+  "hint": "isolated: 隔离模式(群聊/私聊记忆分离); global: 全局模式(基于用户ID，跨群/私聊记忆互通)",
+  "default": "isolated"
+}
 }


### PR DESCRIPTION
## 主要变动 (Key Changes)

1.  **修复记忆上传逻辑 Bug**：修正了 `main.py` 中的代码缩进错误。此前当 `upload_interval` 设置为 1 时，后台保存任务被错误地跳过，导致记忆无法上传。 (#2)

2.  **新增跨场景记忆互通功能 (#4)**：
    *   在配置文件中新增 `memory_scope` 选项，支持 `isolated` (默认，隔离模式) 和 `global` (全局模式)。
    *   开启 `global` 模式后，插件将优先使用发送者的 User ID 而非群组 Session ID，从而实现同一用户在私聊和不同群聊之间的记忆互通。

3.  **优化 Token 消耗，解决 API 报错**：
    *   重构了 `save_memories` 中的消息获取逻辑，强制使用 `event.message_str` (当前消息纯文本) 作为用户输入。
    *   注释了此前使用的 `original_prompts` 缓存机制，避免了在开启 AstrBot 上下文功能时，将包含大量历史记录的 Prompt 全量上传到 MemOS，导致 MemOS API 返回 `Input token limit exceeded` 错误。现在仅上传当前轮次的精简对话，大幅降低 Token 消耗。

## 测试说明
已测试 `upload_interval=1` 下的记忆实时上传，以及开启 `global` 模式后的跨群记忆检索，功能均正常。同时验证了在长上下文场景下，插件不再触发 Token 超限错误。